### PR TITLE
Downgrade diffusers for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffusers
+diffusers==0.16
 Pillow<10.0
 accelerate>=0.11.0
 torch>=1.4


### PR DESCRIPTION
Closes #6 

Currently, running the model results in the error
```
ModuleNotFoundError: No module named 'diffusers.pipeline_utils'
```

Downgrading the diffusers library fixes this issue.